### PR TITLE
fix: OIDC には id-token: write の権限が必要そうなため追加

### DIFF
--- a/.github/workflows/deploy-redash-staging.yml
+++ b/.github/workflows/deploy-redash-staging.yml
@@ -18,6 +18,8 @@ on:
 jobs:
   build_and_deploy_redash_staging:
     name: build and deploy redash staging
+    permissions:
+      id-token: write
     runs-on:
       labels: ubuntu-latest
     steps:


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

GitHub Actions から AWS に OIDC する処理にしていましたが、`id-token: write` の権限がないと失敗するようなので追加しました

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [x] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
